### PR TITLE
replace screenshot URL with a more permanent URL

### DIFF
--- a/io.github.bcpierce00.unison.metainfo.xml
+++ b/io.github.bcpierce00.unison.metainfo.xml
@@ -36,7 +36,7 @@
   </developer>
   <screenshots>
     <screenshot type="default">
-      <image>https://people.freedesktop.org/~mst/unison-screenshot-1.png</image>
+      <image>https://github.com/flathub/io.github.bcpierce00.unison/blob/78ea57b57e81f437a67deb9f587677949643a80f/unison-screenshot-1.png?raw=true</image>
       <caption>The main window, showing changed files</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
screenshot moved to an orphan branch in the git repo.
this shouldn't change anything in practice, just to get familiar with the update process...