### PR TITLE
upgrade to runtime 25.08

### DIFF
--- a/io.github.bcpierce00.unison.metainfo.xml
+++ b/io.github.bcpierce00.unison.metainfo.xml
@@ -24,6 +24,11 @@
   <url type="vcs-browser">https://github.com/bcpierce00/unison</url>
   <launchable type="desktop-id">io.github.bcpierce00.unison.desktop</launchable>
   <releases>
+    <release version="2.53.8-2" date="2026-04-06">
+      <description>
+        <p>Switched to runtime version 25.08.</p>
+      </description>
+    </release>
     <release version="2.53.8" date="2026-01-10">
       <url type="details">https://github.com/bcpierce00/unison/releases/tag/v2.53.8</url>
       <description>

--- a/io.github.bcpierce00.unison.yml
+++ b/io.github.bcpierce00.unison.yml
@@ -1,9 +1,7 @@
 app-id: "io.github.bcpierce00.unison"
 runtime: "org.freedesktop.Platform"
-runtime-version: "24.08"
+runtime-version: "25.08"
 sdk: "org.freedesktop.Sdk"
-sdk-extensions:
-  - "org.freedesktop.Sdk.Extension.ocaml"
 
 command: "unison-gui"
 finish-args:
@@ -20,16 +18,50 @@ finish-args:
   - "--socket=fallback-x11"
 
 build-options:
-  append-path: "/usr/lib/sdk/ocaml/bin"
+  append-path: "/app/share/runtime/ocaml/bin"
   env:
     OCAMLPATH: "/app/share/runtime/ocaml/lib"
 
 cleanup:
-  # delete ocaml static libs, leave license files in place (in doc/)...
-  - "/share/runtime/ocaml/bin"
-  - "/share/runtime/ocaml/lib"
+  # delete ocaml build tools, all licenses have been copied by builder
+  - "/share/runtime"
 
 modules:
+  - name: "ocaml"
+    buildsystem: "autotools"
+    config-opts:
+      - "--prefix=/app/share/runtime/ocaml"
+    sources:
+      - type: "archive"
+        url: "https://github.com/ocaml/ocaml/archive/refs/tags/5.2.0.tar.gz"
+        sha256: "48554abfd530fcdaa08f23f801b699e4f74c320ddf7d0bd56b0e8c24e55fc911"
+
+  - name: "dune"
+    buildsystem: "simple"
+    sources:
+      - type: "archive"
+        url: "https://github.com/ocaml/dune/archive/refs/tags/3.16.0.tar.gz"
+        sha256: "cf141fe2113d95faab9714bc3203f4665ba58c7e0c4450f9a719f1ba075cd214"
+      # bootstrapping problem: dune-rpc-lwt requires lwt requires dune
+      - type: "patch"
+        path: "ocaml-dune-no-lwt.patch"
+    build-commands:
+      - "rm -fr otherlibs/dune-rpc-lwt dune-rpc-lwt.opam"
+      # configure doesn't know prefix?
+      - "./configure
+          --bindir=/app/share/runtime/ocaml/bin
+          --sbindir=/app/share/runtime/ocaml/bin
+          --libdir=/app/share/runtime/ocaml/lib/ocaml
+          --docdir=/app/share/runtime/ocaml/share/doc
+          --mandir=/app/share/runtime/ocaml/share/man
+          --datadir=/app/share/runtime/ocaml/share/data
+          --etcdir=/app/share/runtime/ocaml/etc"
+      - "make release"
+      - "./dune.exe build --verbose --release @install"
+      - "PREFIX=/app/share/runtime/ocaml make install"
+      # install the libraries too (e.g. dune-configurator)
+      - "dune install --prefix /app/share/runtime/ocaml"
+
   - name: "camlp-streams"
     sources:
       - type: "git"
@@ -39,7 +71,7 @@ modules:
     buildsystem: "simple"
     build-commands:
       - "dune build"
-      - "dune install --prefix ${FLATPAK_DEST}/share/runtime/ocaml"
+      - "dune install --prefix /app/share/runtime/ocaml"
 
   - name: "ocaml-cairo"
     sources:
@@ -50,7 +82,7 @@ modules:
     build-commands:
       # avoid building stuff that depends on lablgtk...
       - "dune build -p cairo2 @install"
-      - "dune install -p cairo2 --prefix ${FLATPAK_DEST}/share/runtime/ocaml"
+      - "dune install -p cairo2 --prefix /app/share/runtime/ocaml"
 
   - name: "lablgtk"
     sources:
@@ -60,7 +92,7 @@ modules:
     buildsystem: "simple"
     build-commands:
       - "dune build -p lablgtk3"
-      - "dune install -p lablgtk3 --prefix ${FLATPAK_DEST}/share/runtime/ocaml"
+      - "dune install -p lablgtk3 --prefix /app/share/runtime/ocaml"
 
   - name: "unison"
     sources:

--- a/ocaml-dune-no-lwt.patch
+++ b/ocaml-dune-no-lwt.patch
@@ -1,0 +1,31 @@
+--- dune-3.15.0/dune-file.orig	2024-04-03 03:29:40.000000000 -0600
++++ dune-3.15.0/dune-file	2024-04-05 08:48:56.083804773 -0600
+@@ -30,9 +30,6 @@
+  (copy dune-private-libs.opam.template ordering.opam.template))
+ 
+ (rule
+- (copy dune-private-libs.opam.template dune-rpc-lwt.opam.template))
+-
+-(rule
+  (copy dune-private-libs.opam.template fiber.opam.template))
+ 
+ (rule
+--- dune-3.15.0/dune-project.orig	2024-04-03 03:29:40.000000000 -0600
++++ dune-3.15.0/dune-project	2024-04-05 08:49:50.546090649 -0600
+@@ -149,16 +149,6 @@ understood by dune language."))
+  (description "Library to connect and control a running dune instance"))
+ 
+ (package
+- (name dune-rpc-lwt)
+- (synopsis "Communicate with dune using rpc and Lwt")
+- (depends
+-  (dune-rpc (= :version))
+-  (csexp (>= 1.5.0))
+-  (lwt (>= 5.6.0))
+-  base-unix)
+- (description "Specialization of dune-rpc to Lwt"))
+-
+-(package
+  (name dyn)
+  (synopsis "Dynamic type")
+  (depends


### PR DESCRIPTION
Unfortunately the org.freedesktop.Sdk.Extension.ocaml SDK extension has removed the OCaml toolchain and dune, and only provides opam now.

So remove the SDK extension, and copy the build recipes from its previous version.